### PR TITLE
Add option to disable EorzeaTime seconds for perfs

### DIFF
--- a/packages/app/src/components/EorzeaClock.tsx
+++ b/packages/app/src/components/EorzeaClock.tsx
@@ -3,12 +3,13 @@ import EorzeaTime from 'eorzea-time';
 import React, { FC, useCallback, useEffect, useState } from 'react';
 import { useSettings } from '../context/settings';
 
+const EORZEAN_MINUTE_TO_SECONDS: number = 60 / (1440 / 70);
+
 const EorzeaClock: FC = () => {
   const settings = useSettings();
 
   const [date, setDate] = useState<EorzeaTime>();
   const [isTimerRunning, setTimerRunning] = useState<boolean>();
-  const EORZEAN_MINUTE_TO_SECONDS: number = 60 / (1440 / 70);
 
   const displayDate = (date: EorzeaTime): string => {
     if (settings.state.displaySeconds) {
@@ -19,7 +20,7 @@ const EorzeaClock: FC = () => {
       `0${date.getHours()}`.slice(-2),
       `0${date.getMinutes()}`.slice(-2),
     ].join(':');
-  }
+  };
 
   useEffect(() => {
     let requestID: number;
@@ -36,8 +37,7 @@ const EorzeaClock: FC = () => {
           setDate(new EorzeaTime());
         }, 1000 * EORZEAN_MINUTE_TO_SECONDS);
       }
-    }
-    else {
+    } else {
       const loop = () => {
         setDate(new EorzeaTime());
 
@@ -52,7 +52,6 @@ const EorzeaClock: FC = () => {
     };
   }, [date, setDate, isTimerRunning, setTimerRunning, settings]);
 
-
   const switchMode = useCallback(() => {
     settings.dispatch({
       type: 'setdisplayseconds',
@@ -61,7 +60,12 @@ const EorzeaClock: FC = () => {
   }, [settings]);
 
   return (
-    <Typography color="inherit" variant="body2" style={ { cursor: 'pointer' } } onClick={ switchMode }>
+    <Typography
+      color="inherit"
+      variant="body2"
+      style={{ cursor: 'pointer' }}
+      onClick={switchMode}
+    >
       ET {date ? displayDate(date) : '--:--:--'}
     </Typography>
   );

--- a/packages/app/src/components/EorzeaClock.tsx
+++ b/packages/app/src/components/EorzeaClock.tsx
@@ -1,29 +1,68 @@
 import Typography from '@material-ui/core/Typography';
 import EorzeaTime from 'eorzea-time';
-import React, { FC, useEffect, useState } from 'react';
+import React, { FC, useCallback, useEffect, useState } from 'react';
+import { useSettings } from '../context/settings';
 
 const EorzeaClock: FC = () => {
+  const settings = useSettings();
+
   const [date, setDate] = useState<EorzeaTime>();
+  const [isTimerRunning, setTimerRunning] = useState<boolean>();
+  const EORZEAN_MINUTE_TO_SECONDS: number = 60 / (1440 / 70);
+
+  const displayDate = (date: EorzeaTime): string => {
+    if (settings.state.displaySeconds) {
+      return date.toString();
+    }
+
+    return [
+      `0${date.getHours()}`.slice(-2),
+      `0${date.getMinutes()}`.slice(-2),
+    ].join(':');
+  }
 
   useEffect(() => {
     let requestID: number;
 
-    const loop = () => {
-      setDate(new EorzeaTime());
+    if (!settings.state.displaySeconds) {
+      if (!date) {
+        setDate(new EorzeaTime());
+      }
+
+      if (!isTimerRunning) {
+        setTimerRunning(true);
+        setTimeout(() => {
+          setTimerRunning(false);
+          setDate(new EorzeaTime());
+        }, 1000 * EORZEAN_MINUTE_TO_SECONDS);
+      }
+    }
+    else {
+      const loop = () => {
+        setDate(new EorzeaTime());
+
+        requestID = requestAnimationFrame(loop);
+      };
 
       requestID = requestAnimationFrame(loop);
-    };
-
-    requestID = requestAnimationFrame(loop);
+    }
 
     return () => {
       cancelAnimationFrame(requestID);
     };
-  }, []);
+  }, [date, setDate, isTimerRunning, setTimerRunning, settings]);
+
+
+  const switchMode = useCallback(() => {
+    settings.dispatch({
+      type: 'setdisplayseconds',
+      displaySeconds: !settings.state.displaySeconds,
+    });
+  }, [settings]);
 
   return (
-    <Typography color="inherit" variant="body2">
-      ET {date ? date.toString() : '--:--:--'}
+    <Typography color="inherit" variant="body2" style={ { cursor: 'pointer' } } onClick={ switchMode }>
+      ET {date ? displayDate(date) : '--:--:--'}
     </Typography>
   );
 };

--- a/packages/app/src/context/settings/provider.tsx
+++ b/packages/app/src/context/settings/provider.tsx
@@ -10,6 +10,7 @@ import type { State, Context } from './types';
 
 const initialState: State = {
   dark: null,
+  displaySeconds: true,
 };
 
 // Context and Provider

--- a/packages/app/src/context/settings/reducer.ts
+++ b/packages/app/src/context/settings/reducer.ts
@@ -13,6 +13,12 @@ export default function settingsReducer(state: State, action: Action): State {
         ...state,
         dark: action.dark ?? null,
       };
+
+    case 'setdisplayseconds':
+      return {
+        ...state,
+        displaySeconds: action.displaySeconds ?? false,
+      };
   }
 
   return state;

--- a/packages/app/src/context/settings/types.ts
+++ b/packages/app/src/context/settings/types.ts
@@ -2,13 +2,15 @@ export type BoolOrNull = boolean | null;
 
 export type State = {
   dark: BoolOrNull;
+  displaySeconds: boolean;
 };
 
-export type ActionType = 'load' | 'setdark';
+export type ActionType = 'load' | 'setdark' | 'setdisplayseconds';
 
 export type Action = {
   type: ActionType;
   dark?: BoolOrNull;
+  displaySeconds?: boolean;
   state?: State;
 };
 


### PR DESCRIPTION
Hello,

The constant refresh of the clock uses a lot of CPU time, and was reported to cause FPS drops in FFXIV while open, on some computers.
To avoid removing the idea of showing seconds, but to still let people disable the refresh loop, I've added the option to disable seconds from showing: 
- Instead of a requestAnimationFrame loop, it's using a Timeout set to (60 / (1440 / 70)) seconds, or 2 + 11/12 seconds ;
- You can switch mode by clicking on the clock ;
- The mode is set in the settings through the reducer, so user preference is saved ;
- CPU drops to much lower levels once enabled.

Please note that there's probably 2 main improvement; 
- the ugly `cursor: pointer` style on the link
- the custom `displayDate` function, which should ideally be added to eorzea-time as an option

Finally, thanks for the work you've done on that app :)

Feel free to ask any questions if needed.
